### PR TITLE
Fix active item not losing focus on closing in Firefox and Safari

### DIFF
--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -382,6 +382,15 @@
           dropdown._overlayElement.click();
           expect(dropdown.opened).to.be.false;
         });
+
+        it('should blur the selected item on closing overlay', () => {
+          const blurSpy = sinon.spy();
+          const item = dropdown._items[1];
+          item.blur = blurSpy;
+
+          Enter(item);
+          expect(blurSpy).to.be.called;
+        });
       });
 
       describe('aria', () => {

--- a/vaadin-dropdown-menu.html
+++ b/vaadin-dropdown-menu.html
@@ -322,6 +322,10 @@ This program is available under Apache License Version 2.0, available at https:/
             this._menuElement = Array.from(this._overlayElement.$.content.children).filter(e => e._hasVaadinListMixin)[0];
 
             if (this._menuElement) {
+              this._menuElement.addEventListener('selected-changed', () => this._updateSelectedSlot());
+              this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
+              this._menuElement.addEventListener('click', e => this._closeAndRestore(e));
+
               // To access items content we need menu DOM updated
               Polymer.RenderStatus.afterNextRender(this._menuElement, () => {
                 this._menuElement._observer.flush(); // Ensure observer was run
@@ -378,10 +382,6 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           if (opened) {
-            this._menuElement.addEventListener('selected-changed', () => this._updateSelectedSlot());
-            this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
-            this._menuElement.addEventListener('click', e => this.opened = false);
-
             this._menuElement && Polymer.RenderStatus.afterNextRender(this._menuElement, () => this._menuElement.focus());
             this._setPosition();
             window.addEventListener('scroll', this._boundSetPosition, true);
@@ -408,8 +408,19 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
-        _updateSelectedSlot() {
+        _closeAndRestore() {
+          const selected = this._items[this._menuElement.selected];
+
+          // in Firefox and Safari, selected item stays focused on closing overlay
+          if (selected) {
+            selected.blur();
+          }
+
           this.opened = false;
+        }
+
+        _updateSelectedSlot() {
+          this._closeAndRestore();
           this._selectionElement.innerHTML = '';
 
           const selected = this._items[this._menuElement.selected];


### PR DESCRIPTION
Fixes #44 

The inconsistency between Chrome and Safari / Firefox is that `<vaadin-item>` does not lose focus and therefore preserves `focused`, `focus-ring` and `active` attributes.

I suppose this is related to teleporting. The current solution is to invoke `blur` manually, although I don't really like it.

I feel this should be fixed in `vaadin-item` itself but don't have a solution at the moment.
@manolo WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/47)
<!-- Reviewable:end -->
