### PR TITLE
Add promise for checking when list-box is defined

### DIFF
--- a/vaadin-dropdown-menu.html
+++ b/vaadin-dropdown-menu.html
@@ -330,6 +330,21 @@ This program is available under Apache License Version 2.0, available at https:/
           this._instance = this._createTemplateInstance();
           if (this._instance) {
             this._overlayElement.content = this._instance.root;
+            Promise.all(
+              Array.from(this._overlayElement.$.content.children)
+                .filter(el => /-/.test(el.localName))
+                .map(el => customElements.whenDefined(el.localName))
+            ).then(() => this._ensureMenuElement());
+          }
+        }
+
+        get focusElement() {
+          return this._inputElement ||
+            (this._inputElement = this.shadowRoot.querySelector('vaadin-dropdown-menu-text-field'));
+        }
+
+        _ensureMenuElement() {
+          if (!this._menuElement) {
             this._menuElement = Array.from(this._overlayElement.$.content.children).filter(e => e._hasVaadinListMixin)[0];
 
             if (this._menuElement) {
@@ -340,11 +355,6 @@ This program is available under Apache License Version 2.0, available at https:/
               });
             }
           }
-        }
-
-        get focusElement() {
-          return this._inputElement ||
-            (this._inputElement = this.shadowRoot.querySelector('vaadin-dropdown-menu-text-field'));
         }
 
         /** @private */
@@ -389,6 +399,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           if (opened) {
+            this._ensureMenuElement();
             this._menuElement.addEventListener('selected-changed', () => this._updateSelectedSlot());
             this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
             this._menuElement.addEventListener('click', e => this.opened = false);

--- a/vaadin-dropdown-menu.html
+++ b/vaadin-dropdown-menu.html
@@ -330,6 +330,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._instance = this._createTemplateInstance();
           if (this._instance) {
             this._overlayElement.content = this._instance.root;
+            this._ensureMenuElement();
             Promise.all(
               Array.from(this._overlayElement.$.content.children)
                 .filter(el => /-/.test(el.localName))


### PR DESCRIPTION
Fixes #48 

Thanks to @platosha for showing me promises and `customElements` methods.
Add promise to check when children of the dropdown-menu are defined and find list-box.
Nit: `_ensureMenuElement` method is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/52)
<!-- Reviewable:end -->
