### PR TITLE
Update theme and demos

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "vaadin-themable-mixin": "^1.1.3",
     "vaadin-text-field": "^2.0.0",
     "vaadin-overlay": "^2.0.0",
-    "vaadin-valo-theme": "^2.0.0",
+    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.0.1"
   },
   "devDependencies": {

--- a/demo/dropdown-menu-basic-demos.html
+++ b/demo/dropdown-menu-basic-demos.html
@@ -1,13 +1,13 @@
 <dom-module id="dropdown-menu-basic-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
     </style>
 
     <h3>Basic Usage</h3>
-    <vaadin-demo-snippet id='dropdown-menu-list-box-basic'>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-basic">
       <template preserve-content>
           <vaadin-dropdown-menu>
             <template>
@@ -21,29 +21,16 @@
         </template>
     </vaadin-demo-snippet>
 
-    <h3>Wrapping Long Text</h3>
-    <vaadin-demo-snippet id='dropdown-menu-list-box-wrapping'>
-      <template preserve-content>
-          <vaadin-dropdown-menu>
-            <template>
-              <vaadin-list-box>
-                <vaadin-item>Short value</vaadin-item>
-                <vaadin-item>The longest value in the list</vaadin-item>
-                <vaadin-item>Quite a long value</vaadin-item>
-              </vaadin-list-box>
-            </template>
-          </vaadin-dropdown-menu>
-        </template>
-    </vaadin-demo-snippet>
-
     <h3>Configuring the Dropdown</h3>
-    <vaadin-demo-snippet id='dropdown-menu-list-box-configuring'>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-configuring">
       <template preserve-content>
           <vaadin-dropdown-menu label="Label" placeholder="Placeholder">
             <template>
               <vaadin-list-box>
                 <vaadin-item value="1">Option one</vaadin-item>
                 <vaadin-item value="2">Option two</vaadin-item>
+                <vaadin-item value="3">Option three</vaadin-item>
+                <vaadin-item value="4">Option four</vaadin-item>
               </vaadin-list-box>
             </template>
           </vaadin-dropdown-menu>
@@ -70,6 +57,8 @@
                 <hr>
                 <vaadin-item value="1">Option one</vaadin-item>
                 <vaadin-item value="2">Option two</vaadin-item>
+                <vaadin-item value="3">Option three</vaadin-item>
+                <vaadin-item value="4">Option four</vaadin-item>
               </vaadin-list-box>
             </template>
           </vaadin-dropdown-menu>
@@ -83,7 +72,7 @@
     <p>
       <b>NOTE: The message is not visible initially or when the field is valid</b>
     </p>
-    <vaadin-demo-snippet id='dropdown-menu-error-message'>
+    <vaadin-demo-snippet id="dropdown-menu-error-message">
       <template preserve-content>
         <vaadin-dropdown-menu label="Required, with error message" error-message="Please choose one option" required>
           <template>
@@ -92,6 +81,8 @@
               <hr>
               <vaadin-item value="1">Option one</vaadin-item>
               <vaadin-item value="2">Option two</vaadin-item>
+              <vaadin-item value="3">Option three</vaadin-item>
+              <vaadin-item value="4">Option four</vaadin-item>
             </vaadin-list-box>
           </template>
         </vaadin-dropdown-menu>
@@ -99,7 +90,7 @@
     </vaadin-demo-snippet>
 
     <h3>Custom Label</h3>
-    <vaadin-demo-snippet id='dropdown-menu-list-box-custom-value'>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-value">
       <template preserve-content>
           <vaadin-dropdown-menu placeholder="Language">
             <template>
@@ -115,7 +106,7 @@
     </vaadin-demo-snippet>
 
     <h3>The value property</h3>
-    <vaadin-demo-snippet id='dropdown-menu-list-box-custom-value'>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-value">
       <template preserve-content>
           <vaadin-dropdown-menu placeholder="Language" value="ES">
             <template>
@@ -130,21 +121,11 @@
         </template>
     </vaadin-demo-snippet>
 
-    <h3>TabIndex</h3>
-    <vaadin-demo-snippet id='dropdown-menu-list-box-tabindex'>
-      <template preserve-content>
-          <vaadin-dropdown-menu tabindex="4" label="TabIndex 4"></vaadin-dropdown-menu>
-          <vaadin-dropdown-menu tabindex="3" label="TabIndex 3"></vaadin-dropdown-menu>
-          <vaadin-dropdown-menu tabindex="2" disabled label="TabIndex 2 disabled"></vaadin-dropdown-menu>
-          <vaadin-dropdown-menu tabindex="1" label="TabIndex 1"></vaadin-dropdown-menu>
-        </template>
-    </vaadin-demo-snippet>
-
     <h3>Custom Content</h3>
-    <vaadin-demo-snippet id='dropdown-menu-list-box-custom-content'>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-content">
       <template preserve-content>
           <vaadin-dropdown-menu label="User">
-            <div slot="prefix" style="margin-right: .5em;">👤</div>
+            <div slot="prefix"><iron-icon icon="valo:user"></iron-icon></div>
             <template>
               <vaadin-list-box>
                 <vaadin-item>

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,7 @@
   <link rel="import" href="dropdown-menu-demo.html">
 
   <link rel="import" href="../vaadin-dropdown-menu.html">
-  <link rel="import" href="../../vaadin-valo-theme/icons.html">
+  <link rel="import" href="../../vaadin-valo-styles/icons.html">
 
   <vaadin-component-demo config-src="demos.json"></vaadin-component-demo>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,11 +6,9 @@
   <title>vaadin-dropdown-menu Examples</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <style>
-    body {
-      font-family: sans-serif;
-    }
-  </style>
+  <custom-style>
+     <style include="vaadin-component-demo-shared-styles"></style>
+   </custom-style>
 </head>
 
 <body>
@@ -23,8 +21,8 @@
 
   <link rel="import" href="dropdown-menu-demo.html">
 
-  <link rel="import" href="../../paper-styles/default-theme.html">
   <link rel="import" href="../vaadin-dropdown-menu.html">
+  <link rel="import" href="../../vaadin-valo-theme/icons.html">
 
   <vaadin-component-demo config-src="demos.json"></vaadin-component-demo>
 </body>

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -130,6 +130,11 @@ This program is available under Apache License Version 2.0, available at https:/
         display: inline-block;
       }
 
+      vaadin-dropdown-menu-text-field {
+        width: 100%;
+        min-width: 0;
+      }
+
       :host([hidden]) {
         display: none !important;
       }

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -128,7 +128,6 @@ This program is available under Apache License Version 2.0, available at https:/
     <style>
       :host {
         display: inline-block;
-        width: 175px;
       }
 
       :host([hidden]) {
@@ -150,6 +149,8 @@ This program is available under Apache License Version 2.0, available at https:/
         required="[[required]]"
         invalid="[[invalid]]"
         error-message="[[errorMessage]]"
+        readonly$="[[readonly]]"
+        label$="[[label]]"
       >
       <slot name="prefix" slot="prefix"></slot>
       <div part="value"></div>
@@ -246,7 +247,7 @@ This program is available under Apache License Version 2.0, available at https:/
              */
             label: {
               type: String,
-              value: ''
+              value: undefined
             },
 
             /**

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -247,7 +247,6 @@ This program is available under Apache License Version 2.0, available at https:/
              */
             label: {
               type: String,
-              value: undefined
             },
 
             /**

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -440,20 +440,20 @@
           expect(focusedSpy).to.be.calledOnce;
         });
 
-        it('should set _phone property and phone attribute to true when dimensions are below 420', () => {
+        it('should set _phone property and phone attribute to true when dimensions are below 420', done => {
           expect(dropdown._phone).to.be.false;
           expect(dropdown._overlayElement.hasAttribute('phone')).to.be.false;
 
           window.top.document.querySelector('#subsuites').style.height = '419px';
           window.top.document.querySelector('#subsuites').style.width = '419px';
 
-          setTimeout(() => {
+          dropdown.addEventListener('iron-resize', () => {
             expect(dropdown._phone).to.be.true;
             expect(dropdown._overlayElement.hasAttribute('phone')).to.be.true;
-          }, 1);
-
-          window.top.document.querySelector('#subsuites').style.removeProperty('height');
-          window.top.document.querySelector('#subsuites').style.removeProperty('width');
+            window.top.document.querySelector('#subsuites').style.removeProperty('height');
+            window.top.document.querySelector('#subsuites').style.removeProperty('width');
+            done();
+          });
         });
 
         it('should remove focused state from the input on closing the overlay if phone', () => {

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -122,7 +122,7 @@
       beforeEach(done => {
         dropdown = fixture('withvalue');
         menu = dropdown._menuElement;
-        Polymer.RenderStatus.afterNextRender(menu, done);
+        Polymer.RenderStatus.afterNextRender(menu, () => setTimeout(done));
       });
 
       it('should be possible to set value declaratively', () => {
@@ -444,16 +444,29 @@
           expect(dropdown._phone).to.be.false;
           expect(dropdown._overlayElement.hasAttribute('phone')).to.be.false;
 
-          window.top.document.querySelector('#subsuites').style.height = '419px';
-          window.top.document.querySelector('#subsuites').style.width = '419px';
+          const wrapper = window.top.document.querySelector('#subsuites');
+          const iframe = window.top.document.querySelector('.subsuite');
 
           dropdown.addEventListener('iron-resize', () => {
             expect(dropdown._phone).to.be.true;
             expect(dropdown._overlayElement.hasAttribute('phone')).to.be.true;
-            window.top.document.querySelector('#subsuites').style.removeProperty('height');
-            window.top.document.querySelector('#subsuites').style.removeProperty('width');
+            wrapper.style.removeProperty('height');
+            wrapper.style.removeProperty('width');
+            iframe.style.removeProperty('width');
+            iframe.style.removeProperty('height');
+            iframe.style.removeProperty('minHeight');
+            iframe.style.removeProperty('minWidth');
             done();
           });
+
+          wrapper.style.height = '419px';
+          wrapper.style.width = '419px';
+
+          // fix iframe sizing in iOS
+          iframe.style.width = '0';
+          iframe.style.height = '0';
+          iframe.style.minHeight = '419px';
+          iframe.style.minWidth = '419px';
         });
 
         it('should remove focused state from the input on closing the overlay if phone', () => {

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -108,11 +108,11 @@
     });
 
     describe('vaadin-dropdown-menu inside flexbox', () => {
-      it('dropdown should have some width', () => {
+      it('dropdown should stretch inside a column flex container', () => {
         const container = fixture('dropdown-in-flexbox');
         const dropdown = container.querySelector('vaadin-dropdown-menu');
         expect(window.getComputedStyle(container).width).to.eql('500px');
-        expect(parseFloat(window.getComputedStyle(dropdown).width)).to.be.lte(300);
+        expect(parseFloat(window.getComputedStyle(dropdown).width)).to.eql(500);
       });
     });
 

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -440,34 +440,37 @@
           expect(focusedSpy).to.be.calledOnce;
         });
 
-        it('should set _phone property and phone attribute to true when dimensions are below 420', done => {
-          expect(dropdown._phone).to.be.false;
-          expect(dropdown._overlayElement.hasAttribute('phone')).to.be.false;
+        // iOS 10.3 has broken resize event: https://bugs.webkit.org/show_bug.cgi?id=170595
+        if (!/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+          it('should set _phone property and phone attribute to true when dimensions are below 420', done => {
+            expect(dropdown._phone).to.be.false;
+            expect(dropdown._overlayElement.hasAttribute('phone')).to.be.false;
 
-          const wrapper = window.top.document.querySelector('#subsuites');
-          const iframe = window.top.document.querySelector('.subsuite');
+            const wrapper = window.top.document.querySelector('#subsuites');
+            const iframe = window.top.document.querySelector('.subsuite');
 
-          dropdown.addEventListener('iron-resize', () => {
-            expect(dropdown._phone).to.be.true;
-            expect(dropdown._overlayElement.hasAttribute('phone')).to.be.true;
-            wrapper.style.removeProperty('height');
-            wrapper.style.removeProperty('width');
-            iframe.style.removeProperty('width');
-            iframe.style.removeProperty('height');
-            iframe.style.removeProperty('minHeight');
-            iframe.style.removeProperty('minWidth');
-            done();
+            dropdown.addEventListener('iron-resize', () => {
+              expect(dropdown._phone).to.be.true;
+              expect(dropdown._overlayElement.hasAttribute('phone')).to.be.true;
+              wrapper.style.removeProperty('height');
+              wrapper.style.removeProperty('width');
+              iframe.style.removeProperty('width');
+              iframe.style.removeProperty('height');
+              iframe.style.removeProperty('minHeight');
+              iframe.style.removeProperty('minWidth');
+              done();
+            });
+
+            wrapper.style.height = '419px';
+            wrapper.style.width = '419px';
+
+            // fix iframe sizing in iOS
+            iframe.style.width = '0';
+            iframe.style.height = '0';
+            iframe.style.minHeight = '419px';
+            iframe.style.minWidth = '419px';
           });
-
-          wrapper.style.height = '419px';
-          wrapper.style.width = '419px';
-
-          // fix iframe sizing in iOS
-          iframe.style.width = '0';
-          iframe.style.height = '0';
-          iframe.style.minHeight = '419px';
-          iframe.style.minWidth = '419px';
-        });
+        }
 
         it('should remove focused state from the input on closing the overlay if phone', () => {
           dropdown._phone = true;

--- a/theme/valo/vaadin-dropdown-menu.html
+++ b/theme/valo/vaadin-dropdown-menu.html
@@ -78,7 +78,7 @@
       }
 
       /* TODO not necessarily the best way to target items only */
-      [tabindex] {
+      vaadin-list-box [tabindex] {
         padding-left: calc(var(--valo-space-xs) + var(--valo-border-radius) / 4);
       }
     </style>

--- a/theme/valo/vaadin-dropdown-menu.html
+++ b/theme/valo/vaadin-dropdown-menu.html
@@ -36,10 +36,6 @@
 <dom-module id="valo-dropdown-menu-text-field" theme-for="vaadin-dropdown-menu-text-field">
   <template>
     <style>
-      :host {
-        width: 100%;
-      }
-
       [part="input-field"] {
         cursor: default;
       }
@@ -56,11 +52,6 @@
 
       [part="input-field"]:focus {
         outline: none;
-      }
-
-      [part="value"],
-      [part="input-field"] ::slotted([part="value"]) {
-        width: calc(10em - var(--valo-icon-size));
       }
     </style>
   </template>

--- a/theme/valo/vaadin-dropdown-menu.html
+++ b/theme/valo/vaadin-dropdown-menu.html
@@ -1,10 +1,10 @@
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
-<link rel="import" href="../../../vaadin-valo-theme/font-icons.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/font-icons.html">
 
-<link rel="import" href="../../../vaadin-valo-theme/mixins/menu-overlay.html">
-<link rel="import" href="../../../vaadin-valo-theme/mixins/field-button.html">
+<link rel="import" href="../../../vaadin-valo-styles/mixins/menu-overlay.html">
+<link rel="import" href="../../../vaadin-valo-styles/mixins/field-button.html">
 
 <link rel="import" href="../../../vaadin-text-field/theme/valo/vaadin-text-field.html">
 <link rel="import" href="../../../vaadin-item/theme/valo/vaadin-item.html">

--- a/theme/valo/vaadin-dropdown-menu.html
+++ b/theme/valo/vaadin-dropdown-menu.html
@@ -26,6 +26,7 @@
         content: "\e905";
       }
 
+      /* Highlight the toggle button when hovering over the entire component */
       :host(:hover:not([readonly]):not([disabled])) [part="toggle-button"] {
         color: var(--valo-contrast-80pct);
       }
@@ -68,8 +69,7 @@
         min-width: 10em;
       }
 
-      /* TODO not necessarily the best way to target items only */
-      vaadin-list-box [tabindex] {
+      vaadin-list-box vaadin-item {
         padding-left: calc(var(--valo-space-xs) + var(--valo-border-radius) / 4);
       }
     </style>

--- a/theme/valo/vaadin-dropdown-menu.html
+++ b/theme/valo/vaadin-dropdown-menu.html
@@ -3,17 +3,18 @@
 <link rel="import" href="../../../vaadin-valo-theme/style.html">
 <link rel="import" href="../../../vaadin-valo-theme/font-icons.html">
 
+<link rel="import" href="../../../vaadin-valo-theme/mixins/menu-overlay.html">
+<link rel="import" href="../../../vaadin-valo-theme/mixins/field-button.html">
+
 <link rel="import" href="../../../vaadin-text-field/theme/valo/vaadin-text-field.html">
 <link rel="import" href="../../../vaadin-item/theme/valo/vaadin-item.html">
 <link rel="import" href="../../../vaadin-list-box/theme/valo/vaadin-list-box.html">
-<link rel="import" href="../../../vaadin-overlay/theme/valo/vaadin-overlay.html">
-<link rel="import" href="../../../vaadin-valo-theme/menu-overlay.html">
 
 <dom-module id="valo-dropdown-menu" theme-for="vaadin-dropdown-menu">
   <template>
-    <style>
+    <style include="valo-field-button">
       :host {
-        width: calc(var(--valo-size-m) * 5);
+        -webkit-tap-highlight-color: transparent;
       }
 
       [selected] {
@@ -21,38 +22,12 @@
         padding-right: 0;
       }
 
-      [part$="button"] {
-        flex: none;
-        width: 24px;
-        height: 24px;
-        line-height: 24px;
-        font-size: 24px;
-        text-align: center;
-        color: var(--valo-contrast-40pct);
-        transition: 0.2s color;
-        cursor: default;
-      }
-
-      :host(:hover) [part$="button"] {
-        color: var(--valo-contrast-70pct);
-      }
-
-      [part$="button"]::before {
-        font-family: "valo-icons";
-      }
-
       [part="toggle-button"]::before {
         content: "\e905";
       }
 
-      /* Disabled */
-
-      :host([disabled]) {
-        pointer-events: none;
-      }
-
-      :host([disabled]) [part$="button"] {
-        color: var(--valo-contrast-20pct);
+      :host(:hover:not([readonly]):not([disabled])) [part="toggle-button"] {
+        color: var(--valo-contrast-80pct);
       }
     </style>
   </template>
@@ -65,8 +40,7 @@
         width: 100%;
       }
 
-      [part="input-field"],
-      [part="value"] {
+      [part="input-field"] {
         cursor: default;
       }
 
@@ -83,15 +57,24 @@
       [part="input-field"]:focus {
         outline: none;
       }
+
+      [part="value"],
+      [part="input-field"] ::slotted([part="value"]) {
+        width: calc(10em - var(--valo-icon-size));
+      }
     </style>
   </template>
 </dom-module>
 
 <dom-module id="valo-dropdown-menu-overlay" theme-for="vaadin-dropdown-menu-overlay">
   <template>
-    <style>
+    <style include="valo-menu-overlay">
       :host {
         --_valo-item-selected-icon-display: block;
+      }
+
+      [part~="overlay"] {
+        min-width: 10em;
       }
 
       /* TODO not necessarily the best way to target items only */


### PR DESCRIPTION
Fixes #94 

Depends on https://github.com/vaadin/vaadin-text-field/pull/181

- Remove wrapping example (doesn’t work with Valo)

- Remove tabindex demo (not a best practice)

- Use vaadin-demo-helpers shared styles

- Fix theme to work with latest vaadin-text-field and vaadin-valo-theme
updates

- Reflect `readonly` and `label` to the internal
dropdown-menu-text-field element (the theme uses these attributes)

- Change the label default value to `undefined` (the theme needs a
non-empty string to work correctly)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/93)
<!-- Reviewable:end -->