### PR TITLE
Restore focus-ring if firstly was focused with Tab

### DIFF
--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -454,6 +454,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           if (opened) {
+            this._openedWithFocusRing = this.hasAttribute('focus-ring');
             this._menuElement.addEventListener('selected-changed', () => this._updateValueSlot());
             this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
             this._menuElement.addEventListener('click', e => this.opened = false);
@@ -465,6 +466,9 @@ This program is available under Apache License Version 2.0, available at https:/
               this._setFocused(false);
             } else {
               this.focusElement.focus();
+              if (this._openedWithFocusRing) {
+                this.focusElement.setAttribute('focus-ring', '');
+              }
             }
             this.validate();
             window.removeEventListener('scroll', this._boundSetPosition, true);

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -454,7 +454,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           if (opened) {
-            this._openedWithFocusRing = this.hasAttribute('focus-ring');
+            this._openedWithFocusRing = this.hasAttribute('focus-ring') || this.focusElement.hasAttribute('focus-ring');
             this._menuElement.addEventListener('selected-changed', () => this._updateValueSlot());
             this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
             this._menuElement.addEventListener('click', e => this.opened = false);

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -1,4 +1,4 @@
-<!doctype html>
+!doctype html>
 
 <head>
   <meta charset="UTF-8">
@@ -267,6 +267,13 @@
           dropdown.opened = false;
           expect(dropdown._overlayElement.opened).to.be.false;
           expect(dropdown.opened).to.be.false;
+        });
+
+        it('should restore attribute focus-ring if it was initially set before opening', () => {
+          dropdown.setAttribute('focus-ring', '');
+          dropdown.opened = true;
+          dropdown.opened = false;
+          expect(dropdown.hasAttribute('focus-ring')).to.be.true;
         });
 
         it('overlay should be opened on click event on input field', () => {

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -1,4 +1,4 @@
-!doctype html>
+<!doctype html>
 
 <head>
   <meta charset="UTF-8">
@@ -273,7 +273,7 @@
           dropdown.setAttribute('focus-ring', '');
           dropdown.opened = true;
           dropdown.opened = false;
-          expect(dropdown.hasAttribute('focus-ring')).to.be.true;
+          expect(dropdown.focusElement.hasAttribute('focus-ring')).to.be.true;
         });
 
         it('overlay should be opened on click event on input field', () => {


### PR DESCRIPTION
Fix https://github.com/vaadin/components-team-tasks/issues/306

Restore `focus-ring` if component was firstly focused with <kbd>Tab</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/96)
<!-- Reviewable:end -->
