### PR TITLE
Move small viewport behavior styles from core to Lumo

### DIFF
--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -21,20 +21,6 @@ This program is available under Apache License Version 2.0, available at https:/
         align-items: flex-start;
         justify-content: flex-start;
       }
-
-      [part~="overlay"] {
-        min-width: 175px;
-      }
-
-      :host([phone]) {
-        top: 0 !important;
-        right: 0 !important;
-        bottom: var(--vaadin-overlay-viewport-bottom, 0) !important;
-        left: 0 !important;
-        padding: 24px;
-        align-items: stretch;
-        justify-content: flex-end;
-      }
     </style>
   </template>
 </dom-module>

--- a/theme/lumo/vaadin-dropdown-menu.html
+++ b/theme/lumo/vaadin-dropdown-menu.html
@@ -66,11 +66,18 @@
       }
 
       [part~="overlay"] {
-        min-width: 10em;
+        /* TODO should get the width of the host/text-field element as a custom property */
+        min-width: 12em;
       }
 
-      vaadin-list-box vaadin-item {
-        padding-left: calc(var(--lumo-space-xs) + var(--lumo-border-radius) / 4);
+      /* Small viewport adjustment */
+      :host([phone]) {
+        top: 0 !important;
+        right: 0 !important;
+        bottom: var(--vaadin-overlay-viewport-bottom, 0) !important;
+        left: 0 !important;
+        align-items: stretch;
+        justify-content: flex-end;
       }
     </style>
   </template>


### PR DESCRIPTION
This leaves the decision of the responsive behavior up to the theme to decide, and allows for example to use different behavior for Lumo and Material themes.

Remove the fixed `min-width` at the same time, as that is also the themes decision.

`vaadin-item` padding is handled by the `vaadin-list-box` theme (decouple the styles from `vaadin-dropdown-menu`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/100)
<!-- Reviewable:end -->
