### PR TITLE
Fix incorrect style scope on selected item for initial value

### DIFF
--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -479,6 +479,35 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        _hasContent(selected) {
+          if (!selected) {
+            return false;
+          }
+          return Boolean(
+            selected.hasAttribute('label') ?
+              selected.getAttribute('label') :
+              selected.textContent.trim() || selected.children.length
+          );
+        }
+
+        _attachSelectedItem(selected) {
+          if (!selected) {
+            return;
+          }
+          let labelItem;
+          if (selected.hasAttribute('label')) {
+            labelItem = document.createElement('vaadin-item');
+            labelItem.textContent = selected.getAttribute('label');
+            labelItem.selected = true;
+          } else {
+            labelItem = selected.cloneNode(true);
+          }
+
+          labelItem.removeAttribute('tabindex');
+
+          this._valueElement.appendChild(labelItem);
+        }
+
         _updateAriaExpanded(opened, toggleElement) {
           toggleElement && toggleElement.setAttribute('aria-expanded', opened);
         }
@@ -488,24 +517,18 @@ This program is available under Apache License Version 2.0, available at https:/
           this._valueElement.innerHTML = '';
 
           const selected = this._items[this._menuElement.selected];
-          let hasContent;
-          if (selected) {
-            let labelItem;
-            if (selected.hasAttribute('label')) {
-              hasContent = selected.getAttribute('label');
-              labelItem = document.createElement('vaadin-item');
-              labelItem.textContent = hasContent;
-              labelItem.selected = true;
-            } else {
-              hasContent = selected.textContent.trim() || selected.children.length;
-              labelItem = selected.cloneNode(true);
-            }
-            labelItem.removeAttribute('tabindex');
-            this._valueElement.appendChild(labelItem);
-          }
+
+          const hasContent = this._hasContent(selected);
 
           // Toggle visibility of _valueElement vs fallback input with placeholder
           this._valueElement.slot = hasContent ? 'value' : '';
+
+          // Ensure the slot distribution to apply correct style scope for cloned item
+          if (hasContent && window.ShadyDOM) {
+            window.ShadyDOM.flush();
+          }
+
+          this._attachSelectedItem(selected);
 
           if (!this._valueChanging) {
             this._selectedChanging = true;

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -370,6 +370,9 @@ This program is available under Apache License Version 2.0, available at https:/
               this._menuElement.addEventListener('items-changed', e => {
                 this._items = this._menuElement.items;
               });
+              this._menuElement.addEventListener('selected-changed', () => this._updateValueSlot());
+              this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
+              this._menuElement.addEventListener('click', e => this.opened = false);
             }
           }
         }
@@ -443,9 +446,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
           if (opened) {
             this._openedWithFocusRing = this.hasAttribute('focus-ring') || this.focusElement.hasAttribute('focus-ring');
-            this._menuElement.addEventListener('selected-changed', () => this._updateValueSlot());
-            this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
-            this._menuElement.addEventListener('click', e => this.opened = false);
             this._menuElement.focus();
             this._setPosition();
             window.addEventListener('scroll', this._boundSetPosition, true);

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -56,6 +56,19 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="style-scope">
+    <template>
+      <vaadin-dropdown-menu value="v1">
+        <template>
+          <vaadin-list-box>
+            <mock-item value="v1">t1</mock-item>
+            <mock-item value="v2">t2</mock-item>
+          </vaadin-list-box>
+        </template>
+      </vaadin-dropdown-menu>
+    </template>
+  </test-fixture>
+
   <test-fixture id="dropdown-in-flexbox">
     <template>
       <div style="display: flex; flex-direction: column; width:500px;">
@@ -128,6 +141,21 @@
       it('should be possible to set value declaratively', () => {
         expect(menu.selected).to.be.equal(1);
         expect(dropdown._valueElement.textContent.trim()).to.be.equal('o2');
+      });
+    });
+
+    describe('vaadin-dropdown-menu style scope', () => {
+      let dropdown, menu;
+
+      beforeEach(done => {
+        dropdown = fixture('style-scope');
+        menu = dropdown._menuElement;
+        Polymer.RenderStatus.afterNextRender(menu, () => setTimeout(done));
+      });
+
+      it('should not apply overlay style scope to the clone of selected item', () => {
+        const valueElement = dropdown._valueElement.firstChild;
+        expect(valueElement.classList.contains('vaadin-dropdown-menu-overlay')).to.be.false;
       });
     });
 


### PR DESCRIPTION
Fixes #101 

The problem was in the initial slot distribution not being triggered, so I reorganised code to call `ShadyDOM.flush()` first and then `aappendChild`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/102)
<!-- Reviewable:end -->
