### PR TITLE
Add tests for data binding, remove unused instanceProps

### DIFF
--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -467,10 +467,6 @@ This program is available under Apache License Version 2.0, available at https:/
           const template = this.querySelector('template');
           if (template) {
             const Templatizer = Polymer.Templatize.templatize(template, this, {
-              instanceProps: {
-                detail: true,
-                target: true
-              },
               forwardHostProp: function(prop, value) {
                 this._instance && this._instance.forwardHostProp(prop, value);
               }

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -77,6 +77,41 @@
     </template>
   </test-fixture>
 
+  <dom-module id="x-dropdown">
+    <template>
+      <vaadin-dropdown-menu id="dropdown">
+        <template>
+          <vaadin-list-box>
+            <mock-item value="v1">[[message]]</mock-item>
+            <mock-item value="v2"><input value="{{text::input}}"></mock-item>
+          </vaadin-list-box>
+        </template>
+      </vaadin-dropdown-menu>
+    </template>
+    <script>
+      window.addEventListener('WebComponentsReady', function() {
+        class XDropdown extends Polymer.Element {
+          static get is() {
+            return 'x-dropdown';
+          }
+          static get properties() {
+            return {
+              message: String,
+              text: String
+            };
+          }
+        }
+        window.customElements.define(XDropdown.is, XDropdown);
+      });
+    </script>
+  </dom-module>
+
+  <test-fixture id="binding">
+    <template>
+      <x-dropdown></x-dropdown>
+    </template>
+  </test-fixture>
+
   <script>
     function arrowUp(target) {
       MockInteractions.keyDownOn(target, 38, [], 'ArrowUp');
@@ -156,6 +191,29 @@
       it('should not apply overlay style scope to the clone of selected item', () => {
         const valueElement = dropdown._valueElement.firstChild;
         expect(valueElement.classList.contains('vaadin-dropdown-menu-overlay')).to.be.false;
+      });
+    });
+
+    describe('vaadin-dropdown-menu data binding', function() {
+      let container, dropdown, menu;
+
+      beforeEach(done => {
+        container = fixture('binding');
+        dropdown = container.$.dropdown;
+        menu = dropdown._menuElement;
+        Polymer.RenderStatus.afterNextRender(menu, () => setTimeout(done));
+      });
+
+      it('dropdown-menu should bind parent property', () => {
+        container.message = 'foo';
+        expect(menu.items[0].textContent.trim()).to.equal('foo');
+      });
+
+      it('dropdown-menu should support two-way data binding', () => {
+        const input = menu.items[1].querySelector('input');
+        input.value = 'bar';
+        input.dispatchEvent(new CustomEvent('input'));
+        expect(container.text).to.equal('bar');
       });
     });
 


### PR DESCRIPTION
We apparently have copy-pasted Templatizer code from the `vaadin-context-menu` in several components, including this one. These `instanceProps` (see the [context-menu API docs](https://github.com/vaadin/vaadin-context-menu/blob/master/src/vaadin-context-menu.html#L166)) do not make any sense here and should be removed.

Also added the tests for data binding, based on vaadin/vaadin-notification#54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/105)
<!-- Reviewable:end -->
