### PR TITLE
Expose `--vaadin-dropdown-menu-text-field-width` for the overlay

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "src/vaadin-dropdown-menu.html",
         "start": {
-          "line": 583,
+          "line": 588,
           "column": 6
         },
         "end": {
-          "line": 583,
+          "line": 588,
           "column": 62
         }
       },
@@ -611,7 +611,7 @@
               "inheritedFrom": "Vaadin.OverlayElement"
             },
             {
-              "name": "_cycleTab",
+              "name": "_isFocused",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
@@ -621,7 +621,30 @@
                   "column": 6
                 },
                 "end": {
-                  "line": 485,
+                  "line": 458,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "element"
+                }
+              ],
+              "inheritedFrom": "Vaadin.OverlayElement"
+            },
+            {
+              "name": "_cycleTab",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
+                "start": {
+                  "line": 460,
+                  "column": 6
+                },
+                "end": {
+                  "line": 496,
                   "column": 7
                 }
               },
@@ -643,11 +666,11 @@
               "sourceRange": {
                 "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 487,
+                  "line": 498,
                   "column": 6
                 },
                 "end": {
-                  "line": 491,
+                  "line": 502,
                   "column": 7
                 }
               },
@@ -662,11 +685,11 @@
               "sourceRange": {
                 "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 493,
+                  "line": 504,
                   "column": 6
                 },
                 "end": {
-                  "line": 497,
+                  "line": 508,
                   "column": 7
                 }
               },
@@ -1401,7 +1424,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 304,
+                  "line": 308,
                   "column": 5
                 }
               },
@@ -1743,11 +1766,11 @@
               "sourceRange": {
                 "file": "../bower_components/vaadin-text-field/src/vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 312,
+                  "line": 316,
                   "column": 4
                 },
                 "end": {
-                  "line": 314,
+                  "line": 318,
                   "column": 5
                 }
               },
@@ -1760,17 +1783,36 @@
               "inheritedFrom": "Vaadin.TextFieldMixin"
             },
             {
+              "name": "_addIEListeners",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-text-field/src/vaadin-text-field-mixin.html",
+                "start": {
+                  "line": 320,
+                  "column": 4
+                },
+                "end": {
+                  "line": 333,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.TextFieldMixin"
+            },
+            {
               "name": "_getActiveErrorId",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "file": "../bower_components/vaadin-text-field/src/vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 316,
+                  "line": 335,
                   "column": 4
                 },
                 "end": {
-                  "line": 318,
+                  "line": 337,
                   "column": 5
                 }
               },
@@ -1795,11 +1837,11 @@
               "sourceRange": {
                 "file": "../bower_components/vaadin-text-field/src/vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 320,
+                  "line": 339,
                   "column": 4
                 },
                 "end": {
-                  "line": 322,
+                  "line": 341,
                   "column": 5
                 }
               },
@@ -1821,11 +1863,11 @@
               "sourceRange": {
                 "file": "../bower_components/vaadin-text-field/src/vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 324,
+                  "line": 343,
                   "column": 4
                 },
                 "end": {
-                  "line": 326,
+                  "line": 345,
                   "column": 5
                 }
               },
@@ -1850,11 +1892,11 @@
               "sourceRange": {
                 "file": "../bower_components/vaadin-text-field/src/vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 331,
+                  "line": 350,
                   "column": 4
                 },
                 "end": {
-                  "line": 349,
+                  "line": 368,
                   "column": 5
                 }
               },
@@ -2274,7 +2316,7 @@
           "tagname": "vaadin-dropdown-menu-text-field"
         },
         {
-          "description": "`<vaadin-dropdown-menu>` is a Polymer 2 element for selecting values from a list of items.\n\n```\n<vaadin-dropdown-menu>\n  <template>\n    <vaadin-list-box>\n      <vaadin-item label=\"foo\">Foo</vaadin-item>\n      <vaadin-item>Bar</vaadin-item>\n      <vaadin-item>Baz</vaadin-item>\n    </vaadin-list-box>\n  </template>\n</vaadin-dropdown-menu>\n```\n\nHint: By setting the `label` property of inner vaadin-items you will\nbe able to change the visual representation of the selected value in the input part.\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`toggle-button` | The toggle button\n\nThe following state attributes are available for styling:\n\nAttribute    | Description | Part name\n-------------|-------------|------------\n`opened` | Set when the dropdown menu is open | :host\n`invalid` | Set when the element is invalid | :host\n`focused` | Set when the element is focused | :host\n`focus-ring` | Set when the element is keyboard focused | :host\n`readonly` | Set when the dropdown menu is read only | :host\n\nSee [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)",
+          "description": "`<vaadin-dropdown-menu>` is a Polymer 2 element for selecting values from a list of items.\n\n```\n<vaadin-dropdown-menu>\n  <template>\n    <vaadin-list-box>\n      <vaadin-item label=\"foo\">Foo</vaadin-item>\n      <vaadin-item>Bar</vaadin-item>\n      <vaadin-item>Baz</vaadin-item>\n    </vaadin-list-box>\n  </template>\n</vaadin-dropdown-menu>\n```\n\nHint: By setting the `label` property of inner vaadin-items you will\nbe able to change the visual representation of the selected value in the input part.\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`toggle-button` | The toggle button\n\nThe following state attributes are available for styling:\n\nAttribute    | Description | Part name\n-------------|-------------|------------\n`opened` | Set when the dropdown menu is open | :host\n`invalid` | Set when the element is invalid | :host\n`focused` | Set when the element is focused | :host\n`focus-ring` | Set when the element is keyboard focused | :host\n`readonly` | Set when the dropdown menu is read only | :host\n\n`<vaadin-dropdown-menu>` element sets these custom CSS properties:\n\nProperty name | Description | Theme for element\n--- | --- | ---\n`--vaadin-dropdown-menu-text-field-width` | Width of the menu text field | `vaadin-dropdown-menu-overlay`\n\nSee [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)",
           "summary": "",
           "path": "src/vaadin-dropdown-menu.html",
           "properties": [
@@ -2371,11 +2413,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 224,
+                  "line": 230,
                   "column": 12
                 },
                 "end": {
-                  "line": 230,
+                  "line": 236,
                   "column": 13
                 }
               },
@@ -2394,11 +2436,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 235,
+                  "line": 241,
                   "column": 12
                 },
                 "end": {
-                  "line": 238,
+                  "line": 244,
                   "column": 13
                 }
               },
@@ -2414,11 +2456,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 243,
+                  "line": 249,
                   "column": 12
                 },
                 "end": {
-                  "line": 245,
+                  "line": 251,
                   "column": 13
                 }
               },
@@ -2433,11 +2475,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 260,
+                  "line": 266,
                   "column": 12
                 },
                 "end": {
-                  "line": 265,
+                  "line": 271,
                   "column": 13
                 }
               },
@@ -2456,11 +2498,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 270,
+                  "line": 276,
                   "column": 12
                 },
                 "end": {
-                  "line": 274,
+                  "line": 280,
                   "column": 13
                 }
               },
@@ -2477,11 +2519,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 279,
+                  "line": 285,
                   "column": 12
                 },
                 "end": {
-                  "line": 284,
+                  "line": 290,
                   "column": 13
                 }
               },
@@ -2499,11 +2541,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 289,
+                  "line": 295,
                   "column": 12
                 },
                 "end": {
-                  "line": 292,
+                  "line": 298,
                   "column": 13
                 }
               },
@@ -2518,11 +2560,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 301,
+                  "line": 307,
                   "column": 12
                 },
                 "end": {
-                  "line": 303,
+                  "line": 309,
                   "column": 13
                 }
               },
@@ -2537,11 +2579,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 308,
+                  "line": 314,
                   "column": 12
                 },
                 "end": {
-                  "line": 312,
+                  "line": 318,
                   "column": 13
                 }
               },
@@ -2557,11 +2599,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 314,
+                  "line": 320,
                   "column": 12
                 },
                 "end": {
-                  "line": 314,
+                  "line": 320,
                   "column": 27
                 }
               },
@@ -2576,11 +2618,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 316,
+                  "line": 322,
                   "column": 12
                 },
                 "end": {
-                  "line": 318,
+                  "line": 324,
                   "column": 13
                 }
               },
@@ -2596,11 +2638,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 320,
+                  "line": 326,
                   "column": 12
                 },
                 "end": {
-                  "line": 320,
+                  "line": 326,
                   "column": 35
                 }
               },
@@ -2615,11 +2657,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 322,
+                  "line": 328,
                   "column": 12
                 },
                 "end": {
-                  "line": 322,
+                  "line": 328,
                   "column": 33
                 }
               },
@@ -2634,11 +2676,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 324,
+                  "line": 330,
                   "column": 12
                 },
                 "end": {
-                  "line": 324,
+                  "line": 330,
                   "column": 34
                 }
               },
@@ -2653,11 +2695,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 326,
+                  "line": 332,
                   "column": 12
                 },
                 "end": {
-                  "line": 326,
+                  "line": 332,
                   "column": 26
                 }
               },
@@ -2673,11 +2715,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 349,
+                  "line": 355,
                   "column": 8
                 },
                 "end": {
-                  "line": 377,
+                  "line": 383,
                   "column": 9
                 }
               },
@@ -2690,11 +2732,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 344,
+                  "line": 350,
                   "column": 8
                 },
                 "end": {
-                  "line": 347,
+                  "line": 353,
                   "column": 9
                 }
               },
@@ -2707,11 +2749,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 385,
+                  "line": 391,
                   "column": 8
                 },
                 "end": {
-                  "line": 390,
+                  "line": 396,
                   "column": 9
                 }
               },
@@ -2724,11 +2766,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 553,
+                  "line": 556,
                   "column": 8
                 },
                 "end": {
-                  "line": 558,
+                  "line": 561,
                   "column": 9
                 }
               },
@@ -2894,11 +2936,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 393,
+                  "line": 399,
                   "column": 8
                 },
                 "end": {
-                  "line": 400,
+                  "line": 406,
                   "column": 9
                 }
               },
@@ -2911,11 +2953,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 402,
+                  "line": 408,
                   "column": 8
                 },
                 "end": {
-                  "line": 404,
+                  "line": 410,
                   "column": 9
                 }
               },
@@ -2932,11 +2974,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 406,
+                  "line": 412,
                   "column": 8
                 },
                 "end": {
-                  "line": 418,
+                  "line": 424,
                   "column": 9
                 }
               },
@@ -2956,11 +2998,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 420,
+                  "line": 426,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 431,
                   "column": 9
                 }
               },
@@ -2977,11 +3019,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 427,
+                  "line": 433,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 437,
                   "column": 9
                 }
               },
@@ -2998,11 +3040,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 433,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 463,
+                  "line": 469,
                   "column": 9
                 }
               },
@@ -3022,11 +3064,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 465,
+                  "line": 471,
                   "column": 8
                 },
                 "end": {
-                  "line": 479,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -3039,11 +3081,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 481,
+                  "line": 483,
                   "column": 8
                 },
                 "end": {
-                  "line": 490,
+                  "line": 492,
                   "column": 9
                 }
               },
@@ -3060,11 +3102,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 492,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 508,
+                  "line": 511,
                   "column": 9
                 }
               },
@@ -3081,11 +3123,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 510,
+                  "line": 513,
                   "column": 8
                 },
                 "end": {
-                  "line": 512,
+                  "line": 515,
                   "column": 9
                 }
               },
@@ -3105,11 +3147,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 514,
+                  "line": 517,
                   "column": 8
                 },
                 "end": {
-                  "line": 537,
+                  "line": 540,
                   "column": 9
                 }
               },
@@ -3122,11 +3164,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 539,
+                  "line": 542,
                   "column": 8
                 },
                 "end": {
-                  "line": 550,
+                  "line": 553,
                   "column": 9
                 }
               },
@@ -3146,11 +3188,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 560,
+                  "line": 563,
                   "column": 8
                 },
                 "end": {
-                  "line": 566,
+                  "line": 571,
                   "column": 9
                 }
               },
@@ -3163,11 +3205,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 573,
+                  "line": 578,
                   "column": 8
                 },
                 "end": {
-                  "line": 575,
+                  "line": 580,
                   "column": 9
                 }
               },
@@ -3213,11 +3255,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 205,
+              "line": 211,
               "column": 6
             },
             "end": {
-              "line": 576,
+              "line": 581,
               "column": 7
             }
           },
@@ -3266,11 +3308,11 @@
               "description": "Set when the dropdown menu is open",
               "sourceRange": {
                 "start": {
-                  "line": 224,
+                  "line": 230,
                   "column": 12
                 },
                 "end": {
-                  "line": 230,
+                  "line": 236,
                   "column": 13
                 }
               },
@@ -3282,11 +3324,11 @@
               "description": "The error message to display when the dropdown menu value is invalid",
               "sourceRange": {
                 "start": {
-                  "line": 235,
+                  "line": 241,
                   "column": 12
                 },
                 "end": {
-                  "line": 238,
+                  "line": 244,
                   "column": 13
                 }
               },
@@ -3298,11 +3340,11 @@
               "description": "String used for the label element.",
               "sourceRange": {
                 "start": {
-                  "line": 243,
+                  "line": 249,
                   "column": 12
                 },
                 "end": {
-                  "line": 245,
+                  "line": 251,
                   "column": 13
                 }
               },
@@ -3314,11 +3356,11 @@
               "description": "It stores the the `value` property of the selected item, providing the\nvalue for iron-form.\nWhen there’s an item selected, it's the value of that item, otherwise\nit's an empty string.\nOn change or initialization, the component finds the item which matches the\nvalue and displays it.\nIf no value is provided to the component, it selects the first item without\nvalue or empty value.\nHint: If you do not want to select any item by default, you can either set all\nthe values of inner vaadin-items, or set the vaadin-dropdown-menu value to\nan inexistent value in the items list.",
               "sourceRange": {
                 "start": {
-                  "line": 260,
+                  "line": 266,
                   "column": 12
                 },
                 "end": {
-                  "line": 265,
+                  "line": 271,
                   "column": 13
                 }
               },
@@ -3330,11 +3372,11 @@
               "description": "The current required state of the dropdown menu. True if required.",
               "sourceRange": {
                 "start": {
-                  "line": 270,
+                  "line": 276,
                   "column": 12
                 },
                 "end": {
-                  "line": 274,
+                  "line": 280,
                   "column": 13
                 }
               },
@@ -3346,11 +3388,11 @@
               "description": "Set to true if the value is invalid.",
               "sourceRange": {
                 "start": {
-                  "line": 279,
+                  "line": 285,
                   "column": 12
                 },
                 "end": {
-                  "line": 284,
+                  "line": 290,
                   "column": 13
                 }
               },
@@ -3362,11 +3404,11 @@
               "description": "The name of this element.",
               "sourceRange": {
                 "start": {
-                  "line": 289,
+                  "line": 295,
                   "column": 12
                 },
                 "end": {
-                  "line": 292,
+                  "line": 298,
                   "column": 13
                 }
               },
@@ -3378,11 +3420,11 @@
               "description": "A hint to the user of what can be entered in the control.\nThe placeholder will be displayed in the case that there\nis no item selected, or the selected item has an empty\nstring label, or the selected item has no label and it's\nDOM content is empty.",
               "sourceRange": {
                 "start": {
-                  "line": 301,
+                  "line": 307,
                   "column": 12
                 },
                 "end": {
-                  "line": 303,
+                  "line": 309,
                   "column": 13
                 }
               },
@@ -3394,11 +3436,11 @@
               "description": "When present, it specifies that the element is read-only.",
               "sourceRange": {
                 "start": {
-                  "line": 308,
+                  "line": 314,
                   "column": 12
                 },
                 "end": {
-                  "line": 312,
+                  "line": 318,
                   "column": 13
                 }
               },

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -195,6 +195,12 @@ This program is available under Apache License Version 2.0, available at https:/
        * `focus-ring` | Set when the element is keyboard focused | :host
        * `readonly` | Set when the dropdown menu is read only | :host
        *
+       * `<vaadin-dropdown-menu>` element sets these custom CSS properties:
+       *
+       * Property name | Description | Theme for element
+       * --- | --- | ---
+       * `--vaadin-dropdown-menu-text-field-width` | Width of the menu text field | `vaadin-dropdown-menu-overlay`
+       *
        * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
        *
        * @memberof Vaadin

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -561,6 +561,8 @@ This program is available under Apache License Version 2.0, available at https:/
           this._overlayElement.style.left = inputRect.left + 'px';
           this._overlayElement.style.top = (inputRect.top <= window.innerHeight - inputRect.top ? inputRect.top :
             this._overlayElement.style.top = inputRect.bottom - this._overlayElement.$.overlay.offsetHeight) + 'px';
+
+          this._overlayElement.updateStyles({'--vaadin-dropdown-menu-text-field-width': inputRect.width + 'px'});
         }
 
         /**

--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -422,6 +422,17 @@
           expect(dropdown._overlayElement.getBoundingClientRect().left).to.be.equal(input.getBoundingClientRect().left);
         });
 
+        it('should store the text-field width in the custom CSS property on overlay opening', () => {
+          input.style.width = '200px';
+          dropdown.opened = true;
+
+          const prop = '--vaadin-dropdown-menu-text-field-width';
+          const value = window.ShadyCSS ?
+            window.ShadyCSS.getComputedStyleValue(dropdown._overlayElement, prop) :
+            getComputedStyle(dropdown._overlayElement).getPropertyValue(prop);
+
+          expect(value).to.be.equal(input.getBoundingClientRect().width + 'px');
+        });
       });
 
       describe('disabled', () => {

--- a/theme/lumo/vaadin-dropdown-menu.html
+++ b/theme/lumo/vaadin-dropdown-menu.html
@@ -66,8 +66,7 @@
       }
 
       [part~="overlay"] {
-        /* TODO should get the width of the host/text-field element as a custom property */
-        min-width: 12em;
+        min-width: var(--vaadin-dropdown-menu-text-field-width);
       }
 
       /* Small viewport adjustment */


### PR DESCRIPTION
Allow the overlay to be sized according to the text-field width.

Fixes #97

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/107)
<!-- Reviewable:end -->
