### PR TITLE
Remove animations from tests

### DIFF
--- a/test/dropdown-menu-test.html
+++ b/test/dropdown-menu-test.html
@@ -8,6 +8,7 @@
   <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
   <link rel="import" href="mock-item.html">
   <link rel="import" href="../vaadin-dropdown-menu.html">
+  <link rel="import" href="not-animated-styles.html">
 </head>
 
 <body>

--- a/test/not-animated-styles.html
+++ b/test/not-animated-styles.html
@@ -1,0 +1,12 @@
+<dom-module id="not-animated-dropdown-menu-overlay" theme-for="vaadin-dropdown-menu-overlay">
+  <template>
+    <style include="lumo-dropdown-menu-overlay">
+      :host([opening]),
+      :host([closing]),
+      :host([opening]) [part="overlay"],
+      :host([closing]) [part="overlay"] {
+        animation: none !important;
+      }
+    </style>
+  </template>
+</dom-module>


### PR DESCRIPTION
In the upcoming `vaadin-overlay` release, the animations feature is to be introduced, which in conjunction with the default animation styles in latest Lumo (`lumo-menu-overlay-core`) cause random failures.

Related https://github.com/vaadin/vaadin-combo-box/pull/632

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/110)
<!-- Reviewable:end -->
