### PR TITLE
Reorganize demo structure

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,10 +37,12 @@
     "iron-test-helpers": "^2.0.0",
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
+    "iron-form": "^2.0.0",
     "iron-icon": "^2.0.1",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.0.0",
+    "vaadin-button": "vaadin/vaadin-button#^2.1.0",
     "vaadin-list-box": "vaadin/vaadin-list-box#^1.1.0",
     "vaadin-item": "vaadin/vaadin-item#^2.1.0"
   }

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -1,15 +1,37 @@
 {
   "name": "Vaadin Element",
   "pages": [
-  {
-    "name": "Basics",
-    "url": "dropdown-menu-basic-demos",
-    "src": "dropdown-menu-basic-demos.html",
-    "meta": {
-      "title": "vaadin-dropdown-menu Basics",
-      "description": "",
-      "image": ""
-     }
-  }
+    {
+      "name": "Basics",
+      "url": "dropdown-menu-basic-demos",
+      "src": "dropdown-menu-basic-demos.html",
+      "meta": {
+        "title": "vaadin-dropdown-menu Basics",
+        "description": "",
+        "image": ""
+      }
+    }
+    ,
+    {
+      "name": "Validation",
+      "url": "dropdown-menu-validation-demos",
+      "src": "dropdown-menu-validation-demos.html",
+      "meta": {
+        "title": "vaadin-dropdown-menu Validation",
+        "description": "",
+        "image": ""
+      }
+    }
+    ,
+    {
+      "name": "Styling",
+      "url": "dropdown-menu-styling-demos",
+      "src": "dropdown-menu-styling-demos.html",
+      "meta": {
+        "title": "vaadin-dropdown-menu Styling",
+        "description": "",
+        "image": ""
+      }
+    }
   ]
 }

--- a/demo/dropdown-menu-basic-demos.html
+++ b/demo/dropdown-menu-basic-demos.html
@@ -34,6 +34,7 @@
             </vaadin-list-box>
           </template>
         </vaadin-dropdown-menu>
+
         <vaadin-dropdown-menu label="Disabled" disabled>
           <template>
             <vaadin-list-box>
@@ -42,6 +43,7 @@
             </vaadin-list-box>
           </template>
         </vaadin-dropdown-menu>
+
         <vaadin-dropdown-menu label="Read-only" readonly value="Option one">
           <template>
             <vaadin-list-box>
@@ -50,6 +52,7 @@
             </vaadin-list-box>
           </template>
         </vaadin-dropdown-menu>
+
         <vaadin-dropdown-menu label="Required" required>
           <template>
             <vaadin-list-box>
@@ -65,32 +68,12 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Error Message</h3>
-    <p>
-      The <code>errorMessage</code> property defines a message that gets shown when the selected value is invalid.
-    </p>
-    <p>
-      <b>NOTE: The message is not visible initially or when the field is valid</b>
-    </p>
-    <vaadin-demo-snippet id="dropdown-menu-error-message">
-      <template preserve-content>
-        <vaadin-dropdown-menu label="Required, with error message" error-message="Please choose one option" required>
-          <template>
-            <vaadin-list-box>
-              <vaadin-item value="">Select an option</vaadin-item>
-              <hr>
-              <vaadin-item value="1">Option one</vaadin-item>
-              <vaadin-item value="2">Option two</vaadin-item>
-              <vaadin-item value="3">Option three</vaadin-item>
-              <vaadin-item value="4">Option four</vaadin-item>
-            </vaadin-list-box>
-          </template>
-        </vaadin-dropdown-menu>
-      </template>
-    </vaadin-demo-snippet>
 
-    <h3>Custom Label</h3>
-    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-value">
+    <h3>Customize the Label of Selected Value</h3>
+    <p>
+        By setting the <code>label</code> attribute of inner vaadin-items you will be able to change the visual representation of the selected value in the input part.
+    </p>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-label">
       <template preserve-content>
         <vaadin-dropdown-menu placeholder="Language">
           <template>
@@ -99,71 +82,6 @@
               <vaadin-item label="ES">Spanish</vaadin-item>
               <vaadin-item label="FI">Finnish</vaadin-item>
               <vaadin-item label="EN">English</vaadin-item>
-            </vaadin-list-box>
-          </template>
-        </vaadin-dropdown-menu>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>The Value Property</h3>
-    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-value">
-      <template preserve-content>
-        <vaadin-dropdown-menu placeholder="Language" value="ES">
-          <template>
-            <vaadin-list-box>
-              <vaadin-item value="" label="">Other</vaadin-item>
-              <vaadin-item value="ES" label="Spanish">Spanish (default)</vaadin-item>
-              <vaadin-item value="FI" label="Finnish">Finnish</vaadin-item>
-              <vaadin-item value="EN" label="English">English</vaadin-item>
-            </vaadin-list-box>
-          </template>
-        </vaadin-dropdown-menu>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Styling the Content</h3>
-    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-styling">
-      <template preserve-content>
-        <style>
-          vaadin-item {
-            font-style: italic;
-          }
-        </style>
-        <vaadin-dropdown-menu label="Name">
-          <template>
-            <vaadin-list-box>
-              <vaadin-item>Jose</vaadin-item>
-              <vaadin-item>Manolo</vaadin-item>
-              <vaadin-item>Pedro</vaadin-item>
-            </vaadin-list-box>
-          </template>
-        </vaadin-dropdown-menu>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Custom Content</h3>
-    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-content">
-      <template preserve-content>
-        <vaadin-dropdown-menu label="User">
-          <div slot="prefix"><iron-icon icon="lumo:user"></iron-icon></div>
-          <template>
-            <vaadin-list-box>
-              <vaadin-item>
-                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/women/43.jpg" />
-                &nbsp;Gabriella
-              </vaadin-item>
-              <vaadin-item>
-                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/men/77.jpg" />
-                &nbsp;Rudi
-              </vaadin-item>
-              <vaadin-item>
-                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/men/35.jpg" />
-                &nbsp;Hamsa
-              </vaadin-item>
-              <vaadin-item>
-                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/men/76.jpg" />
-                &nbsp;Jacob
-              </vaadin-item>
             </vaadin-list-box>
           </template>
         </vaadin-dropdown-menu>

--- a/demo/dropdown-menu-styling-demos.html
+++ b/demo/dropdown-menu-styling-demos.html
@@ -1,0 +1,67 @@
+<dom-module id="dropdown-menu-styling-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Styling the Content</h3>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-styling">
+      <template preserve-content>
+        <style>
+          vaadin-item {
+            font-style: italic;
+          }
+        </style>
+        <vaadin-dropdown-menu label="Name">
+          <template>
+            <vaadin-list-box>
+              <vaadin-item>Jose</vaadin-item>
+              <vaadin-item>Manolo</vaadin-item>
+              <vaadin-item>Pedro</vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-dropdown-menu>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Customizing the Content</h3>
+    <vaadin-demo-snippet id="dropdown-menu-list-box-custom-content">
+      <template preserve-content>
+        <vaadin-dropdown-menu label="User">
+          <div slot="prefix"><iron-icon icon="lumo:user"></iron-icon></div>
+          <template>
+            <vaadin-list-box>
+              <vaadin-item>
+                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/women/43.jpg" />
+                &nbsp;Gabriella
+              </vaadin-item>
+              <vaadin-item>
+                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/men/77.jpg" />
+                &nbsp;Rudi
+              </vaadin-item>
+              <vaadin-item>
+                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/men/35.jpg" />
+                &nbsp;Hamsa
+              </vaadin-item>
+              <vaadin-item>
+                <img style="width: 21px; border-radius: 50%; vertical-align: bottom" src="https://randomuser.me/api/portraits/men/76.jpg" />
+                &nbsp;Jacob
+              </vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-dropdown-menu>
+      </template>
+    </vaadin-demo-snippet>
+
+  </template>
+  <script>
+    class DropdownMenuStylingDemos extends DemoReadyEventEmitter(DropdownMenuDemo(Polymer.Element)) {
+      static get is() {
+        return 'dropdown-menu-styling-demos';
+      }
+    }
+    customElements.define(DropdownMenuStylingDemos.is, DropdownMenuStylingDemos);
+  </script>
+</dom-module>

--- a/demo/dropdown-menu-validation-demos.html
+++ b/demo/dropdown-menu-validation-demos.html
@@ -1,0 +1,57 @@
+<dom-module id="dropdown-menu-validation-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Using as a Form Field</h3>
+    <vaadin-demo-snippet id="dropdown-menu-validation">
+      <template preserve-content>
+        <iron-form>
+          <form method="post">
+            <vaadin-dropdown-menu name="title" label="Title" error-message="Please choose the option closes to your profession." required>
+              <template>
+                <vaadin-list-box>
+                  <vaadin-item value="">Select your title</vaadin-item>
+                  <hr>
+                  <vaadin-item value="sales">Account manager</vaadin-item>
+                  <vaadin-item value="design">Designer</vaadin-item>
+                  <vaadin-item value="marketing">Marketing manager</vaadin-item>
+                  <vaadin-item value="dev">Developer</vaadin-item>
+                </vaadin-list-box>
+              </template>
+            </vaadin-dropdown-menu>
+            <vaadin-button>Submit</vaadin-button>
+          </form>
+        </iron-form>
+
+        <script>
+          window.addDemoReadyListener('#dropdown-menu-validation', function(document) {
+            var form = document.querySelector('iron-form');
+
+            form.addEventListener('iron-form-submit', function() {
+              alert('Form submitted with title: ' + form.serializeForm().title);
+              return false;
+            });
+
+            var button = document.querySelector('vaadin-button');
+            button.addEventListener('click', function() {
+              form.submit();
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+  </template>
+  <script>
+    class DropdownMenuValidationDemos extends DemoReadyEventEmitter(DropdownMenuDemo(Polymer.Element)) {
+      static get is() {
+        return 'dropdown-menu-validation-demos';
+      }
+    }
+    customElements.define(DropdownMenuValidationDemos.is, DropdownMenuValidationDemos);
+  </script>
+</dom-module>

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,12 +12,14 @@
   <script src="../../vaadin-demo-helpers/vaadin-demo-ready-event-emitter.js"></script>
   <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
   <link rel="import" href="../../vaadin-item/vaadin-item.html">
+  <link rel="import" href="../../vaadin-button/vaadin-button.html">
 
   <script src="dropdown-menu-demo.js"></script>
 
   <link rel="import" href="../vaadin-dropdown-menu.html">
   <link rel="import" href="../../iron-icon/iron-icon.html">
   <link rel="import" href="../../vaadin-lumo-styles/icons.html">
+  <link rel="import" href="../../iron-form/iron-form.html">
 
   <custom-style>
     <style include="vaadin-component-demo-shared-styles"></style>


### PR DESCRIPTION
Connects to "Guidelines for component examples"

- Removed “Value property” demo. It is already demoed in for example the first “Configuring the dropdown” demo.
- Removed Error message demo.
- Created Validation demo page with similar example as in combo-box.
- Created Styling demo page and moved “Styling” and “Customizing content” demos to that page.
- Added description to Custom label example.
- Modified “Configuring the dropdown” for it to have 1 empty row in between every example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/133)
<!-- Reviewable:end -->
