### PR TITLE
Manual rendering of the content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.1",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.3.2",
     "vaadin-text-field": "vaadin/vaadin-text-field#^2.1.1",
-    "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.0-alpha2",
+    "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.0-alpha3",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0"

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -380,6 +380,13 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * Manually invoke existing renderer.
+         */
+        render() {
+          this._overlayElement.render();
+        }
+
         _removeNewRendererOrTemplate(template, oldTemplate, renderer, oldRenderer) {
           if (template !== oldTemplate) {
             this._contentTemplate = undefined;
@@ -403,7 +410,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           if (renderer) {
             this._overlayElement.setProperties({owner: this, renderer: renderer});
-            this._overlayElement.render();
+            this.render();
 
             if (this._overlayElement.content.firstChild) {
               this._assignMenuElement();

--- a/test/renderer.html
+++ b/test/renderer.html
@@ -104,6 +104,14 @@
           expect(() => dropdown._contentTemplate = template).to.throw(Error);
           expect(dropdown._contentTemplate).to.be.not.ok;
         });
+
+        it('should be possible to manually invoke renderer', () => {
+          const spy = dropdown.renderer = sinon.spy();
+          dropdown.opened = true;
+          spy.reset();
+          dropdown.render();
+          expect(spy).to.be.calledOnce;
+        });
       });
 
       describe('with template', () => {


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/409

Requires https://github.com/vaadin/vaadin-dropdown-menu/pull/157. After applying this [change](https://github.com/vaadin/vaadin-dropdown-menu/pull/157/files#diff-ecc026b97070b7868320a724532e6eadR374) the `_overlayElement` existence will be checked before setting the `renderer`, so there will be no need in checking it in `render` method with lit-element

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/159)
<!-- Reviewable:end -->
