### PR TITLE
Update renderer demos, rollback duplicate menu workarounds

### DIFF
--- a/demo/dropdown-menu-basic-demos.html
+++ b/demo/dropdown-menu-basic-demos.html
@@ -13,6 +13,10 @@
         <script>
           window.addDemoReadyListener('#dropdown-menu-list-box-basic', function(document) {
             document.querySelector('vaadin-dropdown-menu').renderer = function(root) {
+              // use same content, if already rendered
+              if (root.firstChild) {
+                return;
+              }
               // create the <vaadin-list-box>
               const listBox = window.document.createElement('vaadin-list-box');
               // append 3 <vaadin-item> elements
@@ -68,24 +72,36 @@
             };
 
             document.querySelector('vaadin-dropdown-menu[placeholder]').renderer = function(root) {
+              if (root.firstChild) {
+                return;
+              }
               const listBox = window.document.createElement('vaadin-list-box');
               appendItems(listBox, [{textContent: 'Option one'}, {textContent: 'Option two'}]);
               root.appendChild(listBox);
             };
 
             document.querySelector('vaadin-dropdown-menu[disabled]').renderer = function(root) {
+              if (root.firstChild) {
+                return;
+              }
               const listBox = window.document.createElement('vaadin-list-box');
               appendItems(listBox, [{textContent: 'Option one'}]);
               root.appendChild(listBox);
             };
 
             document.querySelector('vaadin-dropdown-menu[readonly]').renderer = function(root) {
+              if (root.firstChild) {
+                return;
+              }
               const listBox = window.document.createElement('vaadin-list-box');
               appendItems(listBox, [{textContent: 'Option one'}]);
               root.appendChild(listBox);
             };
 
             document.querySelector('vaadin-dropdown-menu[required]').renderer = function(root) {
+              if (root.firstChild) {
+                return;
+              }
               const listBox = window.document.createElement('vaadin-list-box');
               // un-selectable <vaadin-item> to highlight required state
               const select = window.document.createElement('vaadin-item');
@@ -119,6 +135,9 @@
         <script>
           window.addDemoReadyListener('#dropdown-menu-list-box-custom-label', function(document) {
             document.querySelector('vaadin-dropdown-menu').renderer = function(root) {
+              if (root.firstChild) {
+                return;
+              }
               const listBox = window.document.createElement('vaadin-list-box');
               const items = [
                 {label: '', textContent: 'Other'},

--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -409,10 +409,10 @@ This program is available under Apache License Version 2.0, available at https:/
           this._oldRenderer = renderer;
 
           if (renderer) {
-            this._overlayElement.setProperties({owner: this, renderer: renderer});
+            overlay.setProperties({owner: this, renderer: renderer});
             this.render();
 
-            if (this._overlayElement.content.firstChild) {
+            if (overlay.content.firstChild) {
               this._assignMenuElement();
             }
           }
@@ -425,16 +425,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this._menuElement.addEventListener('items-changed', e => {
               this._items = this._menuElement.items;
             });
-            this._menuElement.addEventListener('selected-changed', e => {
-              const selected = e.detail.value;
-              const current = this._valueElement.firstElementChild;
-              // when using renderer, event will be triggered on each re-opening,
-              // so check if it was fired for the same item and if so, do nothing
-              if (selected !== undefined && (!current || !this._items[selected].isEqualNode(current._sourceItem))) {
-                this._updateValueSlot();
-                this.opened = false;
-              }
-            });
+            this._menuElement.addEventListener('selected-changed', e => this._updateValueSlot());
             this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
             this._menuElement.addEventListener('click', e => this.opened = false);
           }
@@ -497,11 +488,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _openedChanged(opened, wasOpened) {
           if (opened) {
-            // when using renderer, menu element is created on each re-opening
-            if (this.renderer) {
-              this._assignMenuElement();
-            }
-
             if (
               !this._overlayElement ||
               !this._menuElement ||
@@ -570,6 +556,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _updateValueSlot() {
+          this.opened = false;
           this._valueElement.innerHTML = '';
 
           const selected = this._items[this._menuElement.selected];

--- a/test/renderer.html
+++ b/test/renderer.html
@@ -40,7 +40,7 @@
 
   <dom-module id="x-renderer">
     <template>
-      <vaadin-dropdown-menu renderer="[[renderer]]" opened="{{opened}}"></vaadin-dropdown-menu>
+      <vaadin-dropdown-menu renderer="[[renderer]]"></vaadin-dropdown-menu>
     </template>
     <script>
       customElements.whenDefined('vaadin-dropdown-menu').then(() => {
@@ -50,16 +50,17 @@
           }
           static get properties() {
             return {
-              opened: Boolean,
               renderer: {
                 type: Function,
                 value: function() {
                   return function(root) {
-                    const listBox = document.createElement('vaadin-list-box');
-                    const item = document.createElement('mock-item');
-                    item.textContent = 'renderer item';
-                    listBox.appendChild(item);
-                    root.appendChild(listBox);
+                    if (!root.firstChild) {
+                      const listBox = document.createElement('vaadin-list-box');
+                      const item = document.createElement('mock-item');
+                      item.textContent = 'renderer item';
+                      listBox.appendChild(item);
+                      root.appendChild(listBox);
+                    }
                   };
                 }
               }
@@ -136,13 +137,16 @@
       describe('assigned through property binding', () => {
         let wrapper, dropdown;
 
-        beforeEach(() => {
-          wrapper = fixture('from-props');
-          dropdown = wrapper.shadowRoot.querySelector('vaadin-dropdown-menu');
+        beforeEach(done => {
+          customElements.whenDefined('x-renderer').then(() => {
+            wrapper = fixture('from-props');
+            dropdown = wrapper.shadowRoot.querySelector('vaadin-dropdown-menu');
+            done();
+          });
         });
 
         it('should render correctly when rendered assigned before shadow DOM is ready', () => {
-          wrapper.opened = true;
+          dropdown.opened = true;
           expect(dropdown._overlayElement.content.querySelector('mock-item').textContent.trim()).to.equal('renderer item');
         });
       });


### PR DESCRIPTION
Fixes #163 

Currently, some tests and demos (and parts of implementation related to pre-selecting first item with empty value) rely on menu element to be present before `opened` is set to `true`.

However, in the overlay we now switched to invoke `renderer` after `opened` and #162 was fixing it here, but introduced the regression so here is another fix for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/164)
<!-- Reviewable:end -->
