### PR TITLE
Fix validation demo renderer usage and form submission [skip ci]

### DIFF
--- a/demo/dropdown-menu-validation-demos.html
+++ b/demo/dropdown-menu-validation-demos.html
@@ -20,7 +20,9 @@
           window.addDemoReadyListener('#dropdown-menu-validation', function(document) {
             var form = document.querySelector('iron-form');
 
-            form.addEventListener('iron-form-submit', function() {
+            form.addEventListener('iron-form-presubmit', function(e) {
+              // Prevent actual form submission
+              e.preventDefault();
               alert('Form submitted with title: ' + form.serializeForm().title);
               return false;
             });
@@ -38,6 +40,10 @@
             ];
 
             document.querySelector('vaadin-dropdown-menu').renderer = function(root) {
+              if (root.firstChild) {
+                return;
+              }
+
               const listBox = window.document.createElement('vaadin-list-box');
 
               const select = window.document.createElement('vaadin-item');


### PR DESCRIPTION
Form submission prevention is needed to prevent sending XHR, which produces 404 in all browsers, and hangs in IE11 for some reason related to `iron-request`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/169)
<!-- Reviewable:end -->
